### PR TITLE
Surface errors from external `importjs` call better

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -13,6 +13,10 @@ function importjs#ExecCommand(...)
   let fileContent = join(getline(1, '$'), "\n")
   call add(command, expand("%"))
   let resultString = system(join(command, " "), fileContent)
+  if (v:shell_error)
+    echoerr resultString
+    return
+  endif
   let result = json_decode(resultString)
 
   if (a:1 == "goto" && has_key(result, 'goto'))


### PR DESCRIPTION
If the call to `importjs` fails, we would still try to parse the output
as json. We can detect failures using `v:shell_error` (which returns the
exit code from the last command) and show the output from the command as
an error string instead.

There's still an issue with "^@" showing up in the output, but I figured
this is at least better than what we had before.