### PR TITLE
Adjust cursor based on file line count difference

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -99,6 +99,7 @@ endfunction
 function importjs#ReplaceBuffer(content)
   " Save cursor position so that we can restore it later
   let cursorPos = getpos(".")
+  let originalLineCount = line("$")
   " Delete all lines from the buffer
   execute "%d"
   " Write the resulting content into the buffer
@@ -107,7 +108,10 @@ function importjs#ReplaceBuffer(content)
   execute "put a"
   " Remove lingering line at the top:
   execut ":1d"
-  " Restore cursor position
+  " Restore cursor position, attempting to compensate for the resulting
+  " imports moving the original line up or down
+  let newLineCount = line("$")
+  let cursorPos[1] = cursorPos[1] + newLineCount - originalLineCount
   call setpos(".", cursorPos)
 endfunction
 


### PR DESCRIPTION
When replacing the buffer via `importjs#ReplaceBuffer`, the original
cursor position is restored. However, the file has moved out from
underneath the cursor!

It is a better developer user experience to leave their cursor on the
line of code they started on, which can be calculated by diffing the
line counts and adding it to the original cursor position.

I'm still testing this locally to make sure it works in all cases, but it seems to work for basic addition/removal cases.