### PR TITLE
Improve unresolved imports input

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -119,7 +119,13 @@ function importjs#Resolve(unresolvedImports)
       call add(options, index . ": " . alternative.displayName)
     endfor
     call inputsave()
+
+    " Clear out previous message. This is particularly important if there are
+    " multiple unresolved imports that we will be prompting for.
+    call importjs#Msg("")
+
     let selection = inputlist(options)
+
     call inputrestore()
     if (selection > 0 && selection < len(options))
       let resolved[word] = alternatives[selection - 1].importPath

--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -118,7 +118,9 @@ function importjs#Resolve(unresolvedImports)
       let index = index + 1
       call add(options, index . ": " . alternative.displayName)
     endfor
+    call inputsave()
     let selection = inputlist(options)
+    call inputrestore()
     if (selection > 0 && selection < len(options))
       let resolved[word] = alternatives[selection - 1].importPath
     endif


### PR DESCRIPTION
Preserve and restore typeahead

I was exploring improving the prompt for unresolved imports and
discovered inputsave() and inputrestore(). It is recommended that these
are called before and after calling functions like input() to preserve
typeahead. From vim documentation:

```
inputsave()                                             inputsave()
                Preserve typeahead (also from mappings) and clear it, so
                that a following prompt gets input from the user.
                Should be followed by a matching inputrestore() after
                the prompt.  Can be used several times, in which case
                there must be just as many inputrestore() calls. Returns
                1 when out of memory, 0 otherwise.

inputrestore()                                          inputrestore()
                Restore typeahead that was saved with a previous
                inputsave(). Should be called the same number of times
                inputsave() is called.  Calling it more often is
                harmless though. Returns 1 when there is nothing to
                restore, 0 otherwise.
```
---
Clear prompt in between unresolved imports

If you have multiple unresolved imports, you will be prompted to pick
the module you want for each of them. However, we weren't clearing out
the prompt in between, so it would end up just getting stacked on the
end, resulting in a garbled prompt.

To avoid this, I am making the plugin print an empty message immediately
before printing the inputlist.

Fixes #2

