### PR TITLE
Highlight the unresolved import currently being prompted for

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -112,6 +112,9 @@ endfunction
 function importjs#Resolve(unresolvedImports)
   let resolved = {}
   for [word, alternatives] in items(a:unresolvedImports)
+    " Highlight the word in the buffer
+    let match = matchadd("Search", "\\<" . word . "\\>", -1)
+
     let options = ["ImportJS: Select module to import for `" . word . "`:"]
     let index = 0
     for alternative in alternatives
@@ -127,6 +130,10 @@ function importjs#Resolve(unresolvedImports)
     let selection = inputlist(options)
 
     call inputrestore()
+
+    " Remove the highlight
+    call matchdelete(match)
+
     if (selection > 0 && selection < len(options))
       let resolved[word] = alternatives[selection - 1].importPath
     endif


### PR DESCRIPTION
I want to have a little more context when resolving unresolved imports.
I think it will be helpful to highlight word that is currently being
prompted for. To ensure that this matches "Word" and not "WordFoo" I add
the special word-boundary characters to the matchadd call.

I'd like to also jump to the line that has the word to ensure that it
can be seen, but making sure the cursor ends up back where it belongs
may take a little work so I'm going to get this in as is for now.