### PR TITLE
Jump to word currently being prompted for

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -111,9 +111,15 @@ endfunction
 
 function importjs#Resolve(unresolvedImports)
   let resolved = {}
+
+  " Save cursor position so that we can restore it later
+  let cursorPos = getpos(".")
+
   for [word, alternatives] in items(a:unresolvedImports)
     " Highlight the word in the buffer
     let match = matchadd("Search", "\\<" . word . "\\>", -1)
+    " Jump to the word
+    execute ":ijump \\<" . word . "\\>"
 
     let options = ["ImportJS: Select module to import for `" . word . "`:"]
     let index = 0
@@ -138,6 +144,9 @@ function importjs#Resolve(unresolvedImports)
       let resolved[word] = alternatives[selection - 1].importPath
     endif
   endfor
+
+  call setpos(".", cursorPos)
+
   if (len(resolved))
     call importjs#ExecCommand("add", resolved)
   endif


### PR DESCRIPTION
To help give more context when resolving unresolved imports, I recently
added highlighting of the current word that needs to be resolved. This
commit takes this a step farther by jumping to the line that has the
unresolved word.

It might be nice to center the line vertically in the buffer when we
jump, but for now I'm going to leave this as is and see how it feels.