### PR TITLE
Fix Neovim stdin Parsing Large Files

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -191,13 +191,45 @@ function! importjs#JobExit(job, exitstatus)
   endif
 endfun
 
+" Holds job output that must be joined across multiple outputs for Neovim.
+let s:neovim_job_output = ''
+
+" Neovim sends output in 8192 byte chunks, we must join all of the chunks
+" before handling them. Inspired by https://git.io/v7HcP
+function! importjs#JoinNeovimOutput(last_line, data) abort
+  let l:lines = a:data[:-2]
+
+  if len(a:data) > 1
+    let l:lines[0] = a:last_line . l:lines[0]
+    let l:new_last_line = a:data[-1]
+  else
+    let l:new_last_line = a:last_line . a:data[0]
+  endif
+
+  for l:line in l:lines
+    call importjs#HandleJoinedNeovimInput(l:line)
+  endfor
+
+  return l:new_last_line
+endfunction
+
+function! importjs#HandleJoinedNeovimInput(line)
+  if strpart(a:line, 0, 1) == "{"
+    try
+      call importjs#ParseResult(a:line)
+    catch /E474:/
+      echo 'Invalid JSON, input length: ' . strlen(a:line)
+    endtry
+  endif
+endfunction
+
 " Neovim job handler
 function! s:JobHandler(job_id, data, event) dict
   if a:event == 'stdout'
-    let str = join(a:data)
-    if strpart(str, 0, 1) == "{"
-      call importjs#ParseResult(str)
-    endif
+    let s:neovim_job_output = importjs#JoinNeovimOutput(
+          \   s:neovim_job_output,
+          \   a:data
+          \)
   elseif a:event == 'stderr'
     echoerr "import-js error: " . join(a:data)
   endif

--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -215,11 +215,7 @@ endfunction
 
 function! importjs#HandleJoinedNeovimInput(line)
   if strpart(a:line, 0, 1) == "{"
-    try
-      call importjs#ParseResult(a:line)
-    catch /E474:/
-      echo 'Invalid JSON, input length: ' . strlen(a:line)
-    endtry
+    call importjs#ParseResult(a:line)
   endif
 endfunction
 


### PR DESCRIPTION
Sadly, Neovim breaks output across multiple callbacks when it's larger than 8192 bytes. See https://github.com/neovim/neovim/issues/4266 for more info. You can reproduce this by attempting to run `:ImportJSFix` in a larger JavaScript file.

Solution inspired by https://github.com/w0rp/ale/issues/256, which
resulted in https://github.com/EinfachToll/ale/blob/4b9d402d499a42c816aea42bfec6ee6a31b40bfe/autoload/ale/engine.vim#L85-L103 in Ale.vim. I ported this fix to the single-job environment of import-js.

Tested with Neovim 0.20.0 on Mac 10.12.6. Untested with Vim 8, but I didn't touch any of those code paths.