### PR TITLE
Lazy-load background importjs process

### DIFF
--- a/plugin/import-js.vim
+++ b/plugin/import-js.vim
@@ -1,5 +1,3 @@
 command! ImportJSWord call importjs#Word()
 command! ImportJSGoto call importjs#Goto()
 command! ImportJSFix call importjs#Fix()
-
-call importjs#Init()


### PR DESCRIPTION
Instead of starting an importjs process on vim startup, we can wait
until someone issues the first importjs related command. This will
improve vim startup times and use less memory.

Thanks to @dylan-chong for pushing me in this direction. I had been
meaning to do it for a while but never got around to it.

Fixes #41