### PR TITLE
start import-js automatically when first opening a js file

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -22,7 +22,7 @@ endfunction
 " we get a non-empty response or hit the max number of tries.
 function importjs#TryExecPayload(payload, tryCount)
   if !exists("g:ImportJSChannel")
-    echoerr "If you just added `package.json` just wait a few seconds"
+    echoerr "ImportJS can't run in the current context. You don't have a `package.json` file"
     return
   endif
 

--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -28,7 +28,7 @@ function importjs#TryExecPayload(payload, tryCount)
 
   if exists("*ch_evalraw")
     let resultString = ch_evalraw(g:ImportJSChannel, json_encode(a:payload) . "\n")
-    if (resultString != "")
+    if (resultString != "" || a:payload['command'] == "init")
       return resultString
     endif
   endif
@@ -269,4 +269,6 @@ function! importjs#Init()
     " > ImportJS (v2.10.1) DAEMON active.
     call ch_readraw(g:ImportJSChannel, { "timeout": 2000 })
   endif
+
+  call importjs#ExecCommand("init", "")
 endfunction

--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -51,9 +51,6 @@ function importjs#TryExecPayload(payload, tryCount)
 endfunction
 
 function importjs#ExecCommand(command, arg, ...)
-  " lazy-load the background process
-  call importjs#Init()
-
   let sendContent = (a:0 >= 1) ? a:1 : 1
   if sendContent == 1
     let fileContent = join(getline(1, '$'), "\n")

--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -170,14 +170,10 @@ function importjs#ReplaceBuffer(content)
   " Save cursor position so that we can restore it later
   let cursorPos = getpos(".")
   let originalLineCount = line("$")
-  " Delete all lines from the buffer
-  execute "%d"
-  " Write the resulting content into the buffer
-  let @a = a:content
-  normal! G
-  execute "put a"
-  " Remove lingering line at the top:
-  execut ":1d"
+  "Overwrite the current file
+  execute 'call writefile(split(a:content, "\n"), expand("%"))'
+  "Reopen the file
+  execute 'silent! e!'
   " Restore cursor position, attempting to compensate for the resulting
   " imports moving the original line up or down
   let newLineCount = line("$")

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -9,3 +9,5 @@ endif
 if !hasmapto(':ImportJSGoto<CR>') && maparg('<Leader>g', 'n') == ''
   silent! nnoremap <buffer> <unique> <silent> <Leader>g :ImportJSGoto<CR>
 endif
+
+call importjs#Init()

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -9,5 +9,3 @@ endif
 if !hasmapto(':ImportJSGoto<CR>') && maparg('<Leader>g', 'n') == ''
   silent! nnoremap <buffer> <unique> <silent> <Leader>g :ImportJSGoto<CR>
 endif
-
-call importjs#Init()

--- a/plugin/import-js.vim
+++ b/plugin/import-js.vim
@@ -1,3 +1,13 @@
 command! ImportJSWord call importjs#Word()
 command! ImportJSGoto call importjs#Goto()
 command! ImportJSFix call importjs#Fix()
+
+"call it when entering vim in order to have no lag at all
+call importjs#FindPackageJson(getcwd())
+
+" call on cursorhold since package.json can be created
+" after vim was started
+augroup loadImportJsOnHold
+  au!
+  au CursorHold,CursorHoldI * call importjs#FindPackageJson(getcwd())
+augroup END

--- a/plugin/import-js.vim
+++ b/plugin/import-js.vim
@@ -2,12 +2,10 @@ command! ImportJSWord call importjs#Word()
 command! ImportJSGoto call importjs#Goto()
 command! ImportJSFix call importjs#Fix()
 
-"call it when entering vim in order to have no lag at all
-call importjs#FindPackageJson(getcwd())
-
-" call on cursorhold since package.json can be created
-" after vim was started
 augroup loadImportJsOnHold
   au!
+  au VimEnter * call importjs#FindPackageJson(getcwd())
+  " call on cursorhold since package.json can be created
+  " after vim was started
   au CursorHold,CursorHoldI * call importjs#FindPackageJson(getcwd())
 augroup END


### PR DESCRIPTION
I don't see a reason to make the user have to enter a command and then wait for import-js to initialize.
Starting the process as soon as a javascript file is opened is a better solution I think.